### PR TITLE
Allow setting of different hiera.yaml to use

### DIFF
--- a/spec/classes/hdm_docker_spec.rb
+++ b/spec/classes/hdm_docker_spec.rb
@@ -15,7 +15,7 @@ describe 'hdm' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('docker') }
-      it { is_expected.to contain_file('/etc/hdm/hdm.yml').with(content => /hiera_config_file: "hiera.yaml"/) }
+      it { is_expected.to contain_file('/etc/hdm/hdm.yml').with(content => %r{hiera_config_file: "hiera.yaml"}) }
     end
   end
 end

--- a/spec/classes/hdm_docker_spec.rb
+++ b/spec/classes/hdm_docker_spec.rb
@@ -15,7 +15,7 @@ describe 'hdm' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('docker') }
-      it { is_expected.to contain_file('/etc/hdm/hdm.yml').with(content => %r{hiera_config_file: "hiera.yaml"}) }
+      it { is_expected.to contain_file('/etc/hdm/hdm.yml').with('content' => %r{hiera_config_file: "hiera.yaml"}) }
     end
   end
 end

--- a/spec/classes/hdm_docker_spec.rb
+++ b/spec/classes/hdm_docker_spec.rb
@@ -14,6 +14,8 @@ describe 'hdm' do
       end
 
       it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('docker') }
+      it { is_expected.to contain_file('/etc/hdm/hdm.yml').with(content => /hiera_config_file: "hiera.yaml"/) }
     end
   end
 end

--- a/templates/hdm.yml.epp
+++ b/templates/hdm.yml.epp
@@ -6,6 +6,9 @@
   <%- $hdm::puppetdb_settings.each |$key, $value| { -%>
     <%= $key %>: <%= $value %>
   <%- } -%>
+<%- if $hdm::hdm_hiera_config_file { -%>
+  hiera_config_file: "<%= $hdm::hdm_hiera_config_file %>"
+<- } -%>
   config_dir: <%= $hdm::puppet_code_dir %>
 <%- if ! $hdm::final_ldap_settings.empty { -%>
   ldap:

--- a/templates/hdm.yml.epp
+++ b/templates/hdm.yml.epp
@@ -6,9 +6,7 @@
   <%- $hdm::puppetdb_settings.each |$key, $value| { -%>
     <%= $key %>: <%= $value %>
   <%- } -%>
-<%- if $hdm::hdm_hiera_config_file { -%>
   hiera_config_file: "<%= $hdm::hdm_hiera_config_file %>"
-<- } -%>
   config_dir: <%= $hdm::puppet_code_dir %>
 <%- if ! $hdm::final_ldap_settings.empty { -%>
   ldap:


### PR DESCRIPTION
parameter was available, but the config entry was missing.

fixes #59
