### PR TITLE
Update container env

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -42,6 +42,7 @@ The following parameters are available in the `hdm` class:
 * [`method`](#-hdm--method)
 * [`manage_docker`](#-hdm--manage_docker)
 * [`version`](#-hdm--version)
+* [`container_registry_url`](#-hdm--container_registry_url)
 * [`ruby_version`](#-hdm--ruby_version)
 * [`port`](#-hdm--port)
 * [`bind_ip`](#-hdm--bind_ip)
@@ -95,6 +96,15 @@ the git tag when using rvm
 Please find the releases on HDM website: https://github.com/betadots/hdm/releases
 
 Default value: `'1.0.1'`
+
+##### <a name="-hdm--container_registry_url"></a>`container_registry_url`
+
+Data type: `String[1]`
+
+Configure another registry. Contains the host, path and container name. The version is set via the version parameter.
+e.g. ghcr.io/betadots/hdm
+
+Default value: `'ghcr.io/betadots/hdm'`
 
 ##### <a name="-hdm--ruby_version"></a>`ruby_version`
 

--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -61,6 +61,8 @@ class hdm::docker {
       "TZ=${$hdm::timezone}",
       "RAILS_DEVELOPMENT_HOSTS=${hdm::hostname}",
       "SECRET_KEY_BASE=${hdm::secret_key_base}",
+      "HDM_PORT=${hdm::port}",
+      "HDM_HOST=${hdm::hostname}",
     ],
     volumes  => [
       "${hdm::hdm_path}:${hdm::hdm_path}",

--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -51,12 +51,12 @@ class hdm::docker {
     ensure => file,
   }
 
-  docker::image { 'ghcr.io/betadots/hdm':
+  docker::image { $hdm::container_registry_url:
     image_tag => $hdm::version,
   }
 
   docker::run { 'hdm':
-    image    => "ghcr.io/betadots/hdm:${hdm::version}",
+    image    => "${hdm::container_registry_url}:${hdm::version}",
     env      => [
       "TZ=${$hdm::timezone}",
       "RAILS_DEVELOPMENT_HOSTS=${hdm::hostname}",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,9 @@
 #   the git tag when using rvm
 #   Please find the releases on HDM website: https://github.com/betadots/hdm/releases
 #
+# @param container_registry_url Configure another registry. Contains the host, path and container name. The version is set via the version parameter.
+#   e.g. ghcr.io/betadots/hdm
+#
 # @param ruby_version Select the ruby version when installing using rvm
 #   Please check [hdm ruby version requirement](https://github.com/betadots/hdm/blob/main/.ruby-version)
 #
@@ -122,6 +125,7 @@ class hdm (
   # installation parameter
   String[1]                     $version               = '1.0.1',
   Enum['docker', 'rvm']         $method                = 'docker',
+  String[1]                     $container_registry_url = 'ghcr.io/betadots/hdm',
   Boolean                       $manage_docker         = true,
   String[1]                     $ruby_version          = '3.1.2',
   # required application parameter


### PR DESCRIPTION
Set hostname and port and allow own registry

    We want to allow using different ports and hostnames.
    We pass these information as arguments to the docker container.

    A user wants to make use of a local registry.
    Adding a parameter to hdm calls to set individual registry.