### PR TITLE
Sles support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ If you want to install HDM using RVM, you need the following modules:
 The [puppetlabs-docker](https://forge.puppet.com/modules/puppetlabs/docker/readme) Module lacks official SLES and SuSe support. Yet: the module is usable on SLES.
 
 The installation of Docker can not be done using the module on SLES.
-But one can use any other defined type like `docker::image` or `docker::run`.
+Instead one must install Docker separately within a profile class.
 
-One **must** set the `acknowledge_unsupported_os` parameter to `true` and must tell the module to not manage the docker installation.
+But any other defined type like `docker::image` or `docker::run` is working.
 
-To allow full functionality, the hdm parameter for `manage_docker` must be set to `true`, as we deactivate this in module data.
+One **must** set the `acknowledge_unsupported_os` parameter to `true` to prevent the Docker module from failing on SuSe systems.
 
 Hiera:
 
@@ -85,9 +85,6 @@ Hiera:
 ---
 # Allow Docker to work on SLES
 docker::acknowledge_unsupported_os: true
-docker::manage_package: false
-# Enable HDM to use docker module on SLES
-hdm::manage_docker: true
 ```
 
 ### Beginning with betadots HDM

--- a/data/os/Suse.yaml
+++ b/data/os/Suse.yaml
@@ -1,2 +1,0 @@
----
-hdm::manage_docker: false

--- a/metadata.json
+++ b/metadata.json
@@ -77,6 +77,13 @@
         "18.04",
         "20.04"
       ]
+    },
+    {
+      "operatingsystem": "SLES",
+      "operatingsystemrelease": [
+        "12",
+        "15"
+      ]
     }
   ],
   "requirements": [

--- a/spec/classes/hdm_docker_spec.rb
+++ b/spec/classes/hdm_docker_spec.rb
@@ -12,6 +12,15 @@ describe 'hdm' do
           'version' => '1.0.1',
         }
       end
+      let(:pre_condition) do
+        if facts[:os]['family'] == 'Suse'
+          '
+            class { "docker":
+              acknowledge_unsupported_os => true,
+            }
+          '
+        end
+      end
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('docker') }


### PR DESCRIPTION
use docker with acknowledge_unsupported_os set to true updating documentation
removing unneeded os hiera data
adding sles to supported os
