### PR TITLE
Add additional mounts for docker

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -56,6 +56,7 @@ The following parameters are available in the `hdm` class:
 * [`puppetdb_settings`](#-hdm--puppetdb_settings)
 * [`puppet_dir`](#-hdm--puppet_dir)
 * [`puppet_code_dir`](#-hdm--puppet_code_dir)
+* [`additional_mounts`](#-hdm--additional_mounts)
 * [`disable_authentication`](#-hdm--disable_authentication)
 * [`allow_encryption`](#-hdm--allow_encryption)
 * [`read_only`](#-hdm--read_only)
@@ -243,8 +244,23 @@ Data type: `Stdlib::Unixpath`
 The path where HDM can find deployed
 Puppet environments (similar to puppet config code_dir)
 defaults to '/etc/puppetlabs/code'
+On Puppet Enterprise with lockless deployments this must
+be set to '/etc/puppetlabs/puppetserver/code'
 
 Default value: `'/etc/puppetlabs/code'`
+
+##### <a name="-hdm--additional_mounts"></a>`additional_mounts`
+
+Data type: `Array[Stdlib::Unixpath]`
+
+Provide additional volumes, needed within
+the HDM container. e.g. Directory with ca, cert oand/or key.
+On Puppet Enterprise with lockless deployments, the code dir is a
+symbolic link. One must add
+/opt/puppetlabs/server/data/puppetserver/filesync/client/versioned-dirs'.
+The array is mapped as source:target.
+
+Default value: `[]`
 
 ##### <a name="-hdm--disable_authentication"></a>`disable_authentication`
 

--- a/manifests/docker.pp
+++ b/manifests/docker.pp
@@ -55,6 +55,17 @@ class hdm::docker {
     image_tag => $hdm::version,
   }
 
+  $volumes = [
+    "${hdm::hdm_path}:${hdm::hdm_path}",
+    "${hdm::puppet_dir}:${hdm::puppet_dir}:ro",
+    "${hdm::puppet_code_dir}:${hdm::puppet_code_dir}:ro",
+    "${hdm::hdm_path}/hdm.yml:/hdm/config/hdm.yml:ro",
+    "${hdm::hdm_path}/database.yml:/hdm/config/database.yml:ro",
+  ]
+  $additional_volumes = $hdm::additional_mounts.map |$vol| {
+    "${vol}:${vol}:ro"
+  }
+
   docker::run { 'hdm':
     image    => "${hdm::container_registry_url}:${hdm::version}",
     env      => [
@@ -64,13 +75,7 @@ class hdm::docker {
       "HDM_PORT=${hdm::port}",
       "HDM_HOST=${hdm::hostname}",
     ],
-    volumes  => [
-      "${hdm::hdm_path}:${hdm::hdm_path}",
-      "${hdm::puppet_dir}:${hdm::puppet_dir}:ro",
-      "${hdm::puppet_code_dir}:${hdm::puppet_code_dir}:ro",
-      "${hdm::hdm_path}/hdm.yml:/hdm/config/hdm.yml:ro",
-      "${hdm::hdm_path}/database.yml:/hdm/config/database.yml:ro",
-    ],
+    volumes  => $volumes + $additional_volumes,
     hostname => $hdm::hostname,
     ports    => [$hdm::port],
     net      => 'host',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,6 +79,15 @@
 # @param puppet_code_dir The path where HDM can find deployed
 #   Puppet environments (similar to puppet config code_dir)
 #   defaults to '/etc/puppetlabs/code'
+#   On Puppet Enterprise with lockless deployments this must
+#   be set to '/etc/puppetlabs/puppetserver/code'
+#
+# @param additional_mounts Provide additional volumes, needed within
+#   the HDM container. e.g. Directory with ca, cert oand/or key.
+#   On Puppet Enterprise with lockless deployments, the code dir is a 
+#   symbolic link. One must add
+#   /opt/puppetlabs/server/data/puppetserver/filesync/client/versioned-dirs'.
+#   The array is mapped as source:target.
 #
 # @param disable_authentication Disable user and login
 #   This makes HDM available to anyone.
@@ -159,6 +168,7 @@ class hdm (
   String[1]                     $git_url               = 'https://github.com/betadots/hdm.git',
   Hdm::Puppetdb                 $puppetdb_settings     = { 'server' => 'http://localhost:8080', },
   Stdlib::Unixpath              $puppet_code_dir       = '/etc/puppetlabs/code',
+  Array[Stdlib::Unixpath]       $additional_mounts     = [],
   Stdlib::Unixpath              $puppet_dir            = '/etc/puppetlabs',
   String[1]                     $hdm_hiera_config_file = 'hiera.yaml',
   Stdlib::Unixpath              $global_hiera_yaml     = '/etc/puppetlabs/puppet/hiera.yaml',

--- a/spec/classes/hdm_docker_spec.rb
+++ b/spec/classes/hdm_docker_spec.rb
@@ -51,5 +51,28 @@ describe 'hdm' do
       it { is_expected.to contain_file('/etc/hdm/hdm.yml').with('content' => %r{hiera_config_file: "hiera.yaml"}) }
       it { is_expected.to contain_docker__run('hdm').with('volumes' => %r{/etc/puppetlabs:/etc/puppetlabs:ro}) }
     end
+
+    context "on #{os} using docker with all parameters and additional mounts" do
+      let(:facts) { os_facts }
+      let(:params) do
+        {
+          'method' => 'docker',
+          'version' => '3.0.0',
+          'puppet_dir' => '/etc/puppetlabs',
+          'puppet_code_dir' => '/etc/puppet/code',
+          'additional_mounts' => [
+            '/opt/puppet/code',
+            '/var/puppet',
+          ],
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('docker') }
+      it { is_expected.to contain_file('/etc/hdm/hdm.yml').with('content' => %r{hiera_config_file: "hiera.yaml"}) }
+      it { is_expected.to contain_docker__run('hdm').with('volumes' => %r{/etc/puppetlabs:/etc/puppetlabs:ro}) }
+      it { is_expected.to contain_docker__run('hdm').with('volumes' => %r{/opt/puppet/code:/opt/puppet/code:ro}) }
+      it { is_expected.to contain_docker__run('hdm').with('volumes' => %r{/var/puppet:/var/puppet:ro}) }
+    end
   end
 end


### PR DESCRIPTION
these can be used for:
- ca certs, keys, ca if you use selfsigned ldaps
- additional code dirs (e.g. on PE with versioned deploys)

fixes #110 