### PR TITLE
Update HDM 3.2.0->4.1.1

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -100,7 +100,7 @@ Version is the image tag name when using docker and
 the git tag when using rvm
 Please find the releases on HDM website: https://github.com/betadots/hdm/releases
 
-Default value: `'3.2.0'`
+Default value: `'4.1.1'`
 
 ##### <a name="-hdm--container_registry_url"></a>`container_registry_url`
 
@@ -118,7 +118,7 @@ Data type: `String[1]`
 Select the ruby version when installing using rvm
 Please check [hdm ruby version requirement](https://github.com/betadots/hdm/blob/main/.ruby-version)
 
-Default value: `'3.4.2'`
+Default value: `'3.4.9'`
 
 ##### <a name="-hdm--port"></a>`port`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -84,7 +84,7 @@
 #
 # @param additional_mounts Provide additional volumes, needed within
 #   the HDM container. e.g. Directory with ca, cert oand/or key.
-#   On Puppet Enterprise with lockless deployments, the code dir is a 
+#   On Puppet Enterprise with lockless deployments, the code dir is a
 #   symbolic link. One must add
 #   /opt/puppetlabs/server/data/puppetserver/filesync/client/versioned-dirs'.
 #   The array is mapped as source:target.
@@ -155,11 +155,11 @@
 #
 class hdm (
   # installation parameter
-  String[1]                     $version               = '3.2.0',
+  String[1]                     $version               = '4.1.1',
   Enum['docker', 'rvm']         $method                = 'docker',
   String[1]                     $container_registry_url = 'ghcr.io/betadots/hdm',
   Boolean                       $manage_docker         = true,
-  String[1]                     $ruby_version          = '3.4.2',
+  String[1]                     $ruby_version          = '3.4.9',
   # required application parameter
   Stdlib::Port                  $port                  = 3000,
   Stdlib::IP::Address::Nosubnet $bind_ip               = '0.0.0.0',

--- a/spec/classes/hdm_rvm_spec.rb
+++ b/spec/classes/hdm_rvm_spec.rb
@@ -24,7 +24,7 @@ describe 'hdm' do
       it { is_expected.to contain_class('hdm::rvm') }
       it { is_expected.to contain_rvm__system_user('hdm') }
       it { is_expected.to contain_rvm_gem('bundler') }
-      it { is_expected.to contain_rvm_system_ruby('ruby-3.4.2') }
+      it { is_expected.to contain_rvm_system_ruby('ruby-3.4.9') }
       it { is_expected.to contain_group('hdm') }
       it { is_expected.to contain_user('hdm') }
       it { is_expected.to contain_vcsrepo('/etc/hdm') }


### PR DESCRIPTION
HDM 4.1.1 also requires Ruby 3.4.9.

https://github.com/betadots/hdm/pull/795

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
